### PR TITLE
fix(cybersource): allowing 4 digits for merchant code raw

### DIFF
--- a/CyberSource/models/pts_v2_payments_post201_response_processor_information_merchant_advice.py
+++ b/CyberSource/models/pts_v2_payments_post201_response_processor_information_merchant_advice.py
@@ -98,8 +98,8 @@ class PtsV2PaymentsPost201ResponseProcessorInformationMerchantAdvice(object):
         :param code_raw: The code_raw of this PtsV2PaymentsPost201ResponseProcessorInformationMerchantAdvice.
         :type: str
         """
-        if code_raw is not None and len(code_raw) > 2:
-            raise ValueError("Invalid value for `code_raw`, length must be less than or equal to `2`")
+        if code_raw is not None and len(code_raw) > 4:
+            raise ValueError("Invalid value for `code_raw`, length must be less than or equal to `4`")
 
         self._code_raw = code_raw
 


### PR DESCRIPTION
I've been integrating this SDK to work in Costa Rica for Cornershop. We need to allow a 4 digit merchant code raw because the banking network is using 4 digit instead of 2. There's an image that represent the 4 digit of an authorization process.

![image](https://user-images.githubusercontent.com/1832173/88863837-cca5a800-d1d1-11ea-9e31-4a22ba4292fd.png)
