### PR TITLE
Raise an exception rather than calling sys.exit in library code

### DIFF
--- a/authenticationsdk/util/ExceptionAuth.py
+++ b/authenticationsdk/util/ExceptionAuth.py
@@ -6,7 +6,7 @@ def log_exception(logger, message, mconfig):
         print(message)
         print("Error: Check Log file for more details.")
         logger.exception(message)
-    sys.exit(1)
+    raise Exception(message)
 
 
 
@@ -16,7 +16,7 @@ def validate_merchant_details_log(logger, message, mconfig):
         print(message)
         print("Error: Check Log file for more details.")
         logger.error(message)
-    sys.exit(1)
+    raise Exception(message)
 
 
 


### PR DESCRIPTION
Calling `sys.exit` inside library code (like this client library) is unexpected behavior in python development. It's better to raise an exception with the relevant error message.