### PR TITLE
Remove dependency on 'crypto', which is unused and causes conflicts w…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ DateTime
 setuptools
 six
 urllib3==1.26.5
-crypto
 cryptography

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         "setuptools",
         "six",
         "urllib3==1.26.5",
-        "crypto",
         "cryptography",
     ],
     packages=find_packages(),


### PR DESCRIPTION
…ith pycryptodome on Mac and Windows environments