### PR TITLE
CVE fix, use importlib.metadata instead of pkg_resources

### DIFF
--- a/CyberSource/api_client.py
+++ b/CyberSource/api_client.py
@@ -16,7 +16,7 @@ import json
 import mimetypes
 import tempfile
 import threading
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
 from datetime import date, datetime
 
@@ -105,8 +105,11 @@ class ApiClient(object):
         self.default_headers[header_name] = header_value
 
     def get_client_id(self):
-        version = pkg_resources.require("cybersource-rest-client-python")[0].version
-        return "cybs-rest-sdk-python-" + version
+        try:
+            sdk_version = version("cybersource-rest-client-python")
+        except PackageNotFoundError:
+            sdk_version = "unknown"
+        return "cybs-rest-sdk-python-" + sdk_version
     
     def remove_first_underscore(self, dict_obj):
         converted_dict_obj = {}

--- a/CyberSource/api_client.py
+++ b/CyberSource/api_client.py
@@ -16,7 +16,13 @@ import json
 import mimetypes
 import tempfile
 import threading
-from importlib.metadata import version, PackageNotFoundError
+# Use stdlib importlib.metadata instead of pkg_resources: pkg_resources was
+# removed in setuptools 82, and it was the only thing pulling setuptools in at
+# runtime, so setuptools is no longer a runtime dependency.
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # Python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
 
 from datetime import date, datetime
 

--- a/generator/cybersource-python-template/api_client.mustache
+++ b/generator/cybersource-python-template/api_client.mustache
@@ -8,7 +8,13 @@ import json
 import mimetypes
 import tempfile
 import threading
-from importlib.metadata import version, PackageNotFoundError
+# Use stdlib importlib.metadata instead of pkg_resources: pkg_resources was
+# removed in setuptools 82, and it was the only thing pulling setuptools in at
+# runtime, so setuptools is no longer a runtime dependency.
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # Python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
 
 from datetime import date, datetime
 

--- a/generator/cybersource-python-template/api_client.mustache
+++ b/generator/cybersource-python-template/api_client.mustache
@@ -8,7 +8,7 @@ import json
 import mimetypes
 import tempfile
 import threading
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
 from datetime import date, datetime
 
@@ -97,8 +97,11 @@ class ApiClient(object):
         self.default_headers[header_name] = header_value
 
     def get_client_id(self):
-        version = pkg_resources.require("cybersource-rest-client-python")[0].version
-        return "cybs-rest-sdk-python-" + version
+        try:
+            sdk_version = version("cybersource-rest-client-python")
+        except PackageNotFoundError:
+            sdk_version = "unknown"
+        return "cybs-rest-sdk-python-" + sdk_version
     
     def remove_first_underscore(self, dict_obj):
         converted_dict_obj = {}

--- a/generator/cybersource-python-template/requirements.mustache
+++ b/generator/cybersource-python-template/requirements.mustache
@@ -6,3 +6,4 @@ six
 urllib3-future
 jwcrypto
 cryptography
+importlib_metadata; python_version < "3.8"

--- a/generator/cybersource-python-template/requirements.mustache
+++ b/generator/cybersource-python-template/requirements.mustache
@@ -2,7 +2,6 @@ certifi
 pycryptodome
 PyJWT
 DateTime
-setuptools
 six
 urllib3-future
 jwcrypto

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ six
 urllib3-future
 jwcrypto
 cryptography
+importlib_metadata; python_version < "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ certifi
 pycryptodome
 PyJWT
 DateTime
-setuptools
 six
 urllib3-future
 jwcrypto

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
         "jwcrypto",
         "cryptography",
         "pgpy",
-        "standard-imghdr; python_version >= '3.13'"
+        "standard-imghdr; python_version >= '3.13'",
+        "importlib_metadata; python_version < '3.8'"
     ],
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         "certifi",
         "pycryptodome",
         "DateTime",
-        "setuptools<=81.0.0",
         "six",
         "urllib3-future",
         "jwcrypto",


### PR DESCRIPTION
## The Problem
The pinned setuptools version carries a known vulnerability (CVE-2026-59890, fixed in setuptools 83.0.0). On review, setuptools isn't actually needed at runtime — its only runtime consumer was `pkg_resources` in `CyberSource/api_client.py` -> `get_client_id()` but not beyond that.

## The Fix
Swap that lookup to the stdlib `importlib.metadata` and drop setuptools from `install_requires`, `requirements.txt`, and template. On Python 3.8 and below the import falls back to the `importlib_metadata` backport.

Applied to both the generated `CyberSource/api_client.py` and its generator template (`.../api_client.mustache`) so it survives updates.

## Verification
Test suite passed, no additional tests added.